### PR TITLE
Removed deprecated rubyforge_project line from gemspec file

### DIFF
--- a/rails-footnotes.gemspec
+++ b/rails-footnotes.gemspec
@@ -12,8 +12,6 @@ Gem::Specification.new do |s|
   s.summary     = %q{Every Rails page has footnotes that gives information about your application and links back to your editor.}
   s.description = %q{Every Rails page has footnotes that gives information about your application and links back to your editor.}
 
-  s.rubyforge_project = "rails-footnotes"
-
   s.add_dependency "rails", ">= 3.2"
 
   s.add_development_dependency "rspec-rails", '~> 3.3.2'


### PR DESCRIPTION
Found this today.
```
NOTE: Gem::Specification#rubyforge_project= is deprecated with no replacement. It will be removed on or after 2019-12-01.
Gem::Specification#rubyforge_project= called from /Users/USER/.rvm/gems/ruby-2.7.0-preview1@ruby2.7-rails6.0/bundler/gems/rails-footnotes-5abc557dfae0/rails-footnotes.gemspec:15.
```